### PR TITLE
Provide a config file example

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -1,0 +1,12 @@
+[Folder]
+Source = songs
+Temp = temp
+Image = image
+Output = output
+Distance = distance
+Cluster = cluster
+
+[Fourier]
+warp = 200
+frames = 1
+rate = 6000.0

--- a/example.py
+++ b/example.py
@@ -11,6 +11,8 @@ import os
 config = configparser.ConfigParser()
 config.read('config.ini')
 
+for folder in config['Folder'].values():
+    os.makedirs(folder, exist_ok=True)
 source_folder = config['Folder']['Source']
 temp_folder = config['Folder']['Temp']
 image_folder = config['Folder']['Image']


### PR DESCRIPTION
It took me a few minutes to guess what I had to do to run the example, which probably means other users will have the same experience.

Now they only need to copy the sample config file to `config.ini` and `example.py` will be runnable right away.